### PR TITLE
Update pre-commit-hooks version in Quick start

### DIFF
--- a/sections/install.md
+++ b/sections/install.md
@@ -58,7 +58,7 @@ pre-commit --version
 ```yaml
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v4.3.0
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer


### PR DESCRIPTION
I try pre-commit Quick start and notice pre-commit-hooks version is not latest.  
So update pre-commit-hooks version in Quick start.